### PR TITLE
lasem-dev is not available for arm64

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,7 +9,16 @@ ENTRYPOINT ["/usr/bin/asciidoctor"]
 
 RUN apk update && \
   apk upgrade && \
-  apk add py-pygments py-seqdiag@testing py-nwdiag@testing py-actdiag@testing cmake bison flex-dev mtex2mml-dev && \
+  apk add xz intltool py-pygments py-seqdiag@testing py-nwdiag@testing py-actdiag@testing cmake bison flex-dev mtex2mml-dev gdk-pixbuf-dev gobject-introspection-dev libxml2-dev pango-dev && \
+  curl -sSLo - https://download.gnome.org/sources/lasem/0.5/lasem-0.5.1.tar.xz | tar -xJf - -C /tmp && \
+	cd /tmp/lasem-0.5.1/ && \
+  ./configure --prefix=/usr --mandir=/usr/share/man --localstatedir=/var --disable-silent-rules && \
+  make && \
+  make install && \
+  cd /srv/app && \
+  rm -rf /tmp/lasem-0.5.1/ && \
   gem install asciidoctor asciidoctor-pdf:1.5.0.beta.1 asciidoctor-diagram asciidoctor-epub3:1.5.0.alpha.9 asciidoctor-mathematical asciidoctor-revealjs rouge coderay pygments.rb epubcheck kindlegen && \
-  apk del cmake bison flex-dev mtex2mml-dev && \
+  apk del xz intltool cmake bison flex-dev mtex2mml-dev gdk-pixbuf-dev gobject-introspection-dev libxml2-dev pango-dev && \
   rm -rf /var/cache/apk/*
+
+


### PR DESCRIPTION
That's why we are building it on our own for arm64, otherwise we got to
drop the mathematical part of asciidoctor.